### PR TITLE
moonshot: use 'cycle' command to reboot machine

### DIFF
--- a/app/bmc_types/moonshot.py
+++ b/app/bmc_types/moonshot.py
@@ -37,6 +37,8 @@ class MoonshotBMC(BMCType):
     def set_power(self, machine, power_state):
         bmc = machine.bmc
         try:
+            if power_state == "reset":
+                power_state = "cycle"
             set_power(power_state, host=bmc.ip, username=bmc.username, password=bmc.password,
                       bridge_info=self.get_bridge_info(machine))
         except IPMIError as e:

--- a/app/bmc_types/moonshot.py
+++ b/app/bmc_types/moonshot.py
@@ -37,6 +37,8 @@ class MoonshotBMC(BMCType):
     def set_power(self, machine, power_state):
         bmc = machine.bmc
         try:
+            # Moonshot reacts with error "Unknown (0x80)" to "chassis power reset" command
+            # "chassis power cycle" reboots machine everytime
             if power_state == "reset":
                 power_state = "cycle"
             set_power(power_state, host=bmc.ip, username=bmc.username, password=bmc.password,


### PR DESCRIPTION
IPMI command "chassis power reset" returns error on Moonshot:

Discovered IPMB-0 address 0x20
Discovered Target IPMB-0 address 0x72
Set Chassis Power Control to Reset failed: Unknown (0x80)

But "chassis power cycle" works fine:

Discovered IPMB-0 address 0x20
Discovered Target IPMB-0 address 0x72
Chassis Power Control: Cycle

So let's use it to have some control over rebooting.