### PR TITLE
ui: fix bug around null kernel_opts

### DIFF
--- a/mr_provisioner/admin/ui/src/components/machine/machineEditProvisioning.jsx
+++ b/mr_provisioner/admin/ui/src/components/machine/machineEditProvisioning.jsx
@@ -144,7 +144,7 @@ const formFields = {
     accessor: e => e,
   },
   kernelOpts: {
-    defaultValue: ({ machine }) => machine.kernelOpts,
+    defaultValue: ({ machine }) => machine.kernelOpts || '',
     accessor: e => e.target.value,
   },
   initrdId: {


### PR DESCRIPTION
If kernel_opts was null instead of an empty string, the validation would
fail and prevent saving (unless the kernel_opts field was typed in).

Fix by defaulting to an empty string if it's null.

Fixes: #31