### PR TITLE
api: Fix problems related to machine_put

### DIFF
--- a/mr_provisioner/api/v1/controllers.py
+++ b/mr_provisioner/api/v1/controllers.py
@@ -270,7 +270,7 @@ def machine_put(id):
             raise InvalidUsage('no such initrd')
         elif not initrd.check_permission(g.user, 'user'):
             raise InvalidUsage('not allowed to use initrd', status_code=403)
-        elif kernel.file_type != 'Initrd':
+        elif initrd.file_type != 'Initrd':
             raise InvalidUsage('initrd is not an initrd')
 
     if 'netboot_enabled' in data:

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from mr_provisioner.models import User, Token, BMC, Machine, MachineUsers, Interface, Network, Image
+from mr_provisioner.models import User, Token, BMC, Machine, MachineUsers, Interface, Network, Image, Preseed
 from werkzeug.datastructures import Headers
 
 
@@ -145,7 +145,7 @@ def valid_interface_1(db, valid_plain_machine, valid_network):
 @pytest.fixture(scope='function')
 def valid_image_kernel(db, user_admin):
     image = Image(filename='%s/kernel' % user_admin.username, description='kernel',
-                  file_type='kernel', user_id=user_admin.id,
+                  file_type='Kernel', user_id=user_admin.id,
                   known_good=False, public=True)
     db.session.add(image)
     db.session.commit()
@@ -155,9 +155,20 @@ def valid_image_kernel(db, user_admin):
 
 
 @pytest.fixture(scope='function')
+def valid_preseed(db, user_admin):
+    preseed = Preseed(filename="someseed", description="johnnys seed",
+                      file_type="preseed", file_content="",
+                      user_id=user_admin.id, known_good=False, public=True)
+    db.session.add(preseed)
+    db.session.commit()
+    db.session.refresh(preseed)
+
+    return preseed
+
+@pytest.fixture(scope='function')
 def valid_image_initrd(db, user_admin):
     image = Image(filename='%s/initrd' % user_admin.username, description='initrd',
-                  file_type='initrd', user_id=user_admin.id,
+                  file_type='Initrd', user_id=user_admin.id,
                   known_good=False, public=True)
     db.session.add(image)
     db.session.commit()

--- a/tests/api/test_image.py
+++ b/tests/api/test_image.py
@@ -20,7 +20,7 @@ def test_image_list(client, valid_headers_nonadmin, valid_image_kernel, valid_im
     data = json.loads(r.data.decode('utf-8'))
 
     assert len(data) == 2
-    if data[0]['type'] == 'kernel':
+    if data[0]['type'] == 'Kernel':
         assert data[0]['name'] == valid_image_kernel.filename
         assert data[0]['description'] == valid_image_kernel.description
     else:

--- a/tests/api/test_machine.py
+++ b/tests/api/test_machine.py
@@ -96,6 +96,7 @@ def test_assign_machine_user(client, valid_headers_admin, user_nonadmin, valid_p
         'user': user_nonadmin.username,
         'reason': 'API testing',
     })
+
     r = client.post('/api/v1/machine/%d/assignee' % valid_plain_machine.id, headers=valid_headers_admin, data=body)
     assert r.status_code == 201
 
@@ -173,6 +174,30 @@ def test_change_assignee_self(client, valid_headers_nonadmin, valid_plain_machin
     assert assignees[0].reason == 'API testing'
     assert data['reason'] == 'API testing'
 
+
+def test_set_machine_parameters(client, valid_headers_nonadmin,
+        valid_plain_machine, valid_image_initrd, valid_image_kernel,
+        valid_preseed):
+
+    data = json.dumps({
+        "kernel_id": valid_image_kernel.id,
+        "initrd_id": valid_image_initrd.id,
+        "preseed_id": valid_preseed.id,
+        "kernel_opts": "",
+        "netboot_enabled": True,
+    })
+
+    r = client.put('/api/v1/machine/%d' % valid_plain_machine.id,
+                   headers=valid_headers_nonadmin,
+                   data=data)
+
+    assert r.status_code == 200
+
+    data = json.loads(r.data.decode('utf-8'))
+
+    assert data['initrd_id'] == valid_image_initrd.id
+    assert data['kernel_id'] == valid_image_kernel.id
+    assert data['netboot_enabled'] # is true
 
 def test_machine_interface_empty_list(client, valid_headers_nonadmin, valid_plain_machine):
     r = client.get('/api/v1/machine/%d/interface' % valid_plain_machine.id, headers=valid_headers_nonadmin)


### PR DESCRIPTION
- Typo causing initrd put to always fail
- Inconsistency in file type i.e. Kernel vs kernel, Initrd vs initrd
- Add a test for machine_put
- Add a test for preseed

Signed-off-by: Dan Rue <dan.rue@linaro.org>