### PR TITLE
docs: a few improvements

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -22,7 +22,7 @@ Create a virtual env
 
 Set up a virtual environment to run the application::
 
-    virtualenv env
+    virtualenv --python=python3 env
 
 NOTE: Make sure to specify python 3 if your system doesn't use it by detault
 (-p PYTHON_EXE)
@@ -76,7 +76,7 @@ Start up `ws-subprocess`_::
 
 Start up `tftp-http-proxy`_::
 
-    /path/to/tftp-http-proxy -http-base-url "http://localhost:5000/tftp"
+    /path/to/tftp-http-proxy -http-base-url "http://localhost:5000/tftp/"
 
 And finally, start up `mr-provisioner`::
 

--- a/docs/kea.rst
+++ b/docs/kea.rst
@@ -11,6 +11,8 @@ To build Kea and the `mr-provisioner-kea plugin`_, you need some libraries in ad
 
  - log4cplus (e.g. on Ubuntu: liblog4cplus-dev)
  - curl (e.g. on Ubuntu: libcurl4-openssl-dev or libcurl4-gnutls-dev)
+ - openssl (e.g. on Ubuntu: libssl-dev)
+ - boost c++ (e.g. on Ubuntu: libboost-all-dev)
 
 Install Kea
 ~~~~~~~~~~~~


### PR DESCRIPTION
* Create virtual env with python3.
* Add missing libraries required by kea compilation.
* Append a trailing slash for tftp-http-proxy http base url to avoid 301
  HTTP redirect. Refer to: https://github.com/bwalex/tftp-http-proxy/issues/2

Signed-off-by: Chase Qi <chase.qi@linaro.org>