### PR TITLE
examples: add a trailing slash for tftp proxy http base url

### DIFF
--- a/examples/systemd/mr-provisioner-tftp.service
+++ b/examples/systemd/mr-provisioner-tftp.service
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 ExecStart=/usr/local/bin/tftp-http-proxy \
-	-http-base-url "http://localhost:5000/tftp"
+	-http-base-url "http://localhost:5000/tftp/"
 
 Restart=always
 RestartSec=10


### PR DESCRIPTION
When compiling with golang-1.7, a tftp request returns the below error.

    ERR: http request returned status 400 BAD REQUEST

As explained in https://github.com/bwalex/tftp-http-proxy/issues/2, we
need to avoid the 301 HTTP redirect by either using the correct url(with
a trailing slash) to http-base-url or compiling with golang >=1.8.

Using a trailing slash seems to be a more generic solution. I validated
that it works with both golang-1.7 and golang-1.8.

Signed-off-by: Chase Qi <chase.qi@linaro.org>