### PR TITLE
models.py : set the default interface in debian installer

### DIFF
--- a/mr_provisioner/models.py
+++ b/mr_provisioner/models.py
@@ -719,7 +719,7 @@ class Preseed(db.Model):
 
     def kernel_opts(self, machine, config):
         if self.file_type == "preseed":
-            options = "auto=true priority=critical url=%s interface=auto" % (self.preseed_url(machine, config))
+            options = "auto=true priority=critical url=%s interface=auto BOOTIF=01:$net_default_mac" % (self.preseed_url(machine, config))
 
             if config['PRESEED_DNS']:
                 options += " netcfg/get_nameservers=%s" % (config['PRESEED_DNS'])


### PR DESCRIPTION
If we set BOOTIF=<mac-type>:<macaddr> to $net_default_mac then the installer will always use the interface that we PXE, not the
effectively random first interface that has link available.

01: is the mac-type for ethernet.

Signed-off-by: Graeme Gregory <graeme.gregory@linaro.org>