### PR TITLE
grub.netboot.tmpl : add passing PXE interface as BOOTIF

### DIFF
--- a/mr_provisioner/netboot_templates/grub.netboot.tmpl
+++ b/mr_provisioner/netboot_templates/grub.netboot.tmpl
@@ -1,8 +1,10 @@
 set default="linux"
 set timeout=3
 
+tr -s net_default_mac_dash : - $net_default_mac
+
 menuentry "linux" {
-	linux (tftp)/{{machine.kernel.filename}} {{machine.kernel_opts_all(config)}}
+	linux (tftp)/{{machine.kernel.filename}} {{machine.kernel_opts_all(config)}} BOOTIF=01-$net_default_mac_dash
 {% if machine.initrd.filename %}
 	initrd (tftp)/{{machine.initrd.filename}}
 {% endif %}


### PR DESCRIPTION
If we pass the PXE interface with BOOTIF= then debian/centos installer can
use this information to automatically use the same interface ininstaller.
This will stop the problem we are currently experiencing where installer
selects first interface with link which makes it effectively random.

01- is the harware type for ethernet.

Signed-off-by: Graeme Gregory <graeme.gregory@linaro.org>