### PR TITLE
Basic docker-based development environment

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# Usage: ./dev.sh
+#
+# Create a standalone local development environment in an ephemeral docker
+# container.
+#
+# The container will operate as your UID and mount in your local path to /work.
+# It will install mr_provisioner, set up and start postgresql, run all database
+# migrations, run tests, run linters, run mr_provisioner on localhost:5000 in
+# the background, and also return a bash shell.
+#
+# From the docker shell, interactively run "make test", "make lint", etc while
+# editing files in real-time.
+#
+# Log into the web interface with admin/linaro:
+# http://localhost:5000/
+# http://localhost:5000/api/v1/docs
+
+
+set -eu
+
+cp dev/Dockerfile.dev-template dev/Dockerfile.dev
+
+cat << EOF >> dev/Dockerfile.dev
+RUN groupadd -g $(id -g) $(id -gn)
+RUN useradd -m -u $(id -u) -g $(id -g) -s /bin/bash ${USER}
+RUN echo '${USER} ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
+USER ${USER}
+
+CMD dev/test-and-run.sh; bash
+EOF
+
+docker build -t prov -f dev/Dockerfile.dev .
+docker run --rm -p 5000:5000 -v $(pwd):/work -it prov

--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile.dev

--- a/dev/Dockerfile.dev-template
+++ b/dev/Dockerfile.dev-template
@@ -1,0 +1,17 @@
+FROM debian:stretch
+
+RUN apt-get update && apt-get install -y vim python3 python3-pip postgresql libpq-dev build-essential libssl-dev curl sudo less gnupg
+
+# Node repo, curl | bash style 😩
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+
+# Yarn repo 🚀
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+RUN apt-get update && apt-get install -y nodejs yarn
+
+WORKDIR /work
+
+ENV APP_DATABASE_URI "postgresql+psycopg2://provuser:provuser@localhost/provisioner"
+

--- a/dev/test-and-run.sh
+++ b/dev/test-and-run.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eux
+
+cd /work
+sudo pip3 install -r requirements.txt -r requirements.dev.txt
+
+(cd mr_provisioner/admin/ui && yarn install && npm run build && npm run lint)
+
+sudo /etc/init.d/postgresql start
+sudo -u postgres psql -c 'create database provisioner;'
+sudo -u postgres psql -c "create role provuser with password 'provuser' login;"
+sudo -u postgres psql -c 'grant all privileges on database provisioner to provuser;'
+python3 run.py db upgrade
+make test
+make lint
+python3 run.py runserver -d -r -h 0.0.0.0 -p 5000 &

--- a/docs/dev/getting_started.rst
+++ b/docs/dev/getting_started.rst
@@ -16,3 +16,28 @@ First, make sure the virtual env is activated.
 Start up the development server by running::
 
     ./run.py -c /path/to/your/config.ini runserver -h 0.0.0.0 -p 5000 -d -r
+
+Develop with Docker!
+--------------------
+
+Alternatively, use the standalone docker development environment.
+
+Usage:
+
+    ./dev.sh
+
+dev.sh creates a standalone local development environment in an ephemeral
+docker container.
+
+The container will operate as your UID and mount in your local mr-provisioner
+source path to /work. It will install mr_provisioner, set up and start
+postgresql, run all database migrations, run tests, run linters (javascript and
+python), run mr_provisioner on localhost:5000 in the background, and also
+return a bash shell.
+
+From the docker shell, interactively run "make test", "make lint", etc while
+editing files in real-time.
+
+Log into the web interface with username admin, password linaro @
+http://localhost:5000/
+


### PR DESCRIPTION
Usage:

    ./dev.sh

dev.sh creates a standalone local development environment in an ephemeral
docker container.

The container will operate as your UID and mount in your local mr-provisioner
source path to /work. It will install mr_provisioner, set up and start
postgresql, run all database migrations, run tests, run linters (javascript and
python), run mr_provisioner on localhost:5000 in the background, and also
return a bash shell.

From the docker shell, interactively run "make test", "make lint", etc while
editing files in real-time.

Log into the web interface with username admin, password linaro @
http://localhost:5000/

Signed-off-by: Dan Rue <dan.rue@linaro.org>