### PR TITLE
ui: fix log download for newer browser versions

### DIFF
--- a/mr_provisioner/admin/ui/src/components/machine/machineConsole.jsx
+++ b/mr_provisioner/admin/ui/src/components/machine/machineConsole.jsx
@@ -105,9 +105,7 @@ class MachineConsole_ extends React.Component {
 
   handleOpenLog = ev => {
     ev.preventDefault()
-    window.open(
-      'data:text/plain;base64,' + encodeURIComponent(window.btoa(this.log))
-    )
+    window.open().document.write(this.log)
   }
 
   render() {


### PR DESCRIPTION
Browsers nowadays block data:URLs for security reasons, so use a plain
document.write() on a new window instead.

See https://bugs.chromium.org/p/chromium/issues/detail?id=684011&desc=2
for details on the browser behaviour.

Fixes: #43