### PR TITLE
api, tests: fix bug around images without user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.2.8 (unreleased)
 
+Bug fixes:
+
+ - api: fix bug around listing images (#68)
+
 ## v0.2.7 (2018-01-16)
 
 Big-ticket items:

--- a/mr_provisioner/api/v1/controllers.py
+++ b/mr_provisioner/api/v1/controllers.py
@@ -64,7 +64,7 @@ def serialize_image(image):
         'type': image.file_type,
         'arch': image.arch.name if image.arch else None,
         'upload_date': image.date,
-        'user': image.user.username,
+        'user': image.user.username if image.user else None,
         'known_good': image.known_good,
         'public': image.public,
     }

--- a/tests/api/test_image.py
+++ b/tests/api/test_image.py
@@ -28,6 +28,16 @@ def test_image_list(client, valid_headers_nonadmin, valid_image_kernel, valid_im
         assert data[0]['description'] == valid_image_initrd.description
 
 
+def test_image_list_with_default_bootloader(client, valid_headers_nonadmin, valid_image_kernel, valid_image_initrd, valid_image_bootloader_no_user):
+    r = client.get('/api/v1/image?show_all=true', headers=valid_headers_nonadmin)
+
+    assert r.status_code == 200
+
+    data = json.loads(r.data.decode('utf-8'))
+
+    assert len(data) == 3
+
+
 def test_create_image(client, valid_headers_nonadmin, user_nonadmin, valid_arch):
     q = json.dumps({
         'description': 'Uploaded image',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,6 +272,19 @@ def valid_image_bootloader(db, user_admin, valid_arch):
 
 
 @pytest.fixture(scope='function')
+def valid_image_bootloader_no_user(db, valid_arch):
+    image = Image(filename='bootloader', description='bootloader',
+                  file_type='bootloader', user_id=None,
+                  arch_id=valid_arch.id,
+                  known_good=False, public=True)
+    db.session.add(image)
+    db.session.commit()
+    db.session.refresh(image)
+
+    return image
+
+
+@pytest.fixture(scope='function')
 def machines_for_reservation(db, valid_bmc_plain, valid_bmc_moonshot, user_nonadmin, valid_arch, valid_arch2):
     machines = [
         Machine(name='machine0', bmc_id=valid_bmc_plain.id, arch_id=valid_arch.id),


### PR DESCRIPTION
In principle, it should only apply to the magical bootloader image that
gets added as part of multiarch migrations from earlier revisions of
mr-provisioner.

Fixes: #68