### PR TITLE
grub.netboot.tmpl: fix position of BOOTIF=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.3.0 (unreleased)
 
+Bug fixes:
+
+ - grub.netboot.tmpl: fixing position of BOOTIF= argument to solve problems with --- in cmdline being used from UI.
+
 ## v0.2.9 (2018-02-16)
 
 Big-ticket items:

--- a/mr_provisioner/netboot_templates/grub.netboot.tmpl
+++ b/mr_provisioner/netboot_templates/grub.netboot.tmpl
@@ -4,7 +4,7 @@ set timeout=3
 tr -s net_default_mac_dash : - $net_default_mac
 
 menuentry "linux" {
-	linux (tftp)/{{machine.kernel.filename}} {{machine.kernel_opts_all(config)}} BOOTIF=01-$net_default_mac_dash
+	linux (tftp)/{{machine.kernel.filename}} BOOTIF=01-$net_default_mac_dash {{machine.kernel_opts_all(config)}}
 {% if machine.initrd.filename %}
 	initrd (tftp)/{{machine.initrd.filename}}
 {% endif %}


### PR DESCRIPTION
Originally BOOTIF= was put at the end of cmdline, but this
means if you use --- in provisioning options to set params
if /etc/default/grub BOOTIF gets entered too. Move it to earlier
in cmdline.

Signed-off-by: Graeme Gregory <graeme.gregory@linaro.org>